### PR TITLE
bugfix(hooks): add hooks processing logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-allure2-reporter",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Allure 2 reporter for Mocha framework",
   "main": "index.js",
   "keywords": [
@@ -38,6 +38,7 @@
     "fs-jetpack": "^2.2.0",
     "husky": "^1.1.2",
     "lint-staged": "^7.3.0",
+    "lodash": "^4.17.11",
     "mocha": "^5.2.0",
     "mocha-typescript": "^1.1.17",
     "nyc": "^13.1.0",

--- a/src/MochaAllureInterface.ts
+++ b/src/MochaAllureInterface.ts
@@ -17,6 +17,18 @@ export class MochaAllureInterface extends AllureInterface {
     super();
   }
 
+  public get currentExecutable(): ExecutableItemWrapper {
+    const executable = this.reporter.currentStep || this.reporter.currentTest || this.reporter.currentExecutable;
+    if (executable === null) {
+      throw new Error('No executable!');
+    }
+    return executable;
+  }
+
+  public set currentExecutable(executable: ExecutableItemWrapper) {
+    this.reporter.currentExecutable = executable;
+  }
+
   public setDescription(text: string) {
     this.currentTest.description = text;
     this.currentTest.descriptionHtml = text;
@@ -116,13 +128,5 @@ export class MochaAllureInterface extends AllureInterface {
       throw new Error('No test running!');
     }
     return this.reporter.currentTest;
-  }
-
-  private get currentExecutable(): ExecutableItemWrapper {
-    const executable = this.reporter.currentStep || this.reporter.currentTest;
-    if (executable === null) {
-      throw new Error('No executable!');
-    }
-    return executable;
   }
 }

--- a/src/MochaAllureReporter.ts
+++ b/src/MochaAllureReporter.ts
@@ -19,7 +19,9 @@ export class MochaAllureReporter extends Mocha.reporters.Base {
       .on('test', this.onTest.bind(this))
       .on('pass', this.onPassed.bind(this))
       .on('fail', this.onFailed.bind(this))
-      .on('pending', this.onPending.bind(this));
+      .on('pending', this.onPending.bind(this))
+      .on('hook', this.onHookStart.bind(this))
+      .on('hook end', this.onHookEnd.bind(this));
   }
 
   private onSuite(suite: Mocha.Suite) {
@@ -45,5 +47,13 @@ export class MochaAllureReporter extends Mocha.reporters.Base {
 
   private onPending(test: Mocha.Test) {
     allure.pendingTestCase(test);
+  }
+
+  private onHookStart(hook: Mocha.Hook) {
+    allure.startHook(hook.title);
+  }
+
+  private onHookEnd(hook: Mocha.Hook) {
+    allure.endHook(hook.error());
   }
 }

--- a/test/fixtures/specs/attachment.ts
+++ b/test/fixtures/specs/attachment.ts
@@ -20,4 +20,8 @@ class AttachmentSubSuite {
     });
     allure.testAttachment('test attachment 2', '{ "key": "value" }', ContentType.JSON);
   }
+
+  public after() {
+    allure.attachment('after test attachment 1', 'after test attachment content', ContentType.TEXT);
+  }
 }

--- a/test/specs/attachment.ts
+++ b/test/specs/attachment.ts
@@ -10,6 +10,7 @@ import {
   runTests,
   whenResultsAppeared
 } from '../utils';
+import { findAfterTestAttachments } from '../utils/index';
 
 @suite
 class AttachmentsSuite {
@@ -47,6 +48,11 @@ class AttachmentsSuite {
       expect(stepAttachments[0].type).eq('text/plain');
       expect(stepAttachments[1].name).eq('step 2 attachment 2');
       expect(stepAttachments[1].type).eq('text/plain');
+
+      const afterTestAttachments = findAfterTestAttachments('AttachmentSubSuite');
+      expect(afterTestAttachments).length(1);
+      expect(afterTestAttachments[0].name).eq('after test attachment 1');
+      expect(afterTestAttachments[0].type).eq('text/plain');
     });
   }
 }

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,4 +1,5 @@
-import jetpack = require('fs-jetpack');
+import * as jetpack from 'fs-jetpack';
+import * as _ from 'lodash';
 import * as Mocha from 'mocha';
 import * as path from 'path';
 import * as PropertiesReader from 'properties-reader';
@@ -62,6 +63,14 @@ export function findAttachments(testName: string): any[] {
 
 export function findStepAttachments(testName: string, stepName: string): any[] {
   return findStep(testName, stepName).attachments;
+}
+
+export function findAfterTestAttachments(testName: string): any[] {
+  return _.flatten(findTestAfters(testName).map(after => after.attachments));
+}
+
+export function findTestAfters(testName: string): any[] {
+  return findTest(testName).afters;
 }
 
 export function findLinks(testName: string): any[] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1618,7 +1618,7 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash@^4.17.10, lodash@^4.17.5:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==


### PR DESCRIPTION
Currently, it's not possible to attach anything in after hook, as test context has already vanished. It's required to tune reporter to support before/after hooks processing.

METADATA: fixes #3, fixes https://github.com/sskorol/ts-test-decorators/issues/10